### PR TITLE
Store file lengths as `uint64` to avoid problems with the big files on the 32-bit systems

### DIFF
--- a/download/bitfield/bitfield.go
+++ b/download/bitfield/bitfield.go
@@ -44,7 +44,7 @@ func (bitfield *Bitfield) ToBytes() []byte {
 	return bitfield.data
 }
 
-func (bitfield *Bitfield) AddPiece(piece int) {
+func (bitfield *Bitfield) AddPiece(piece uint64) {
 	byteIdx := piece / 8
 	bitIdx := piece % 8
 
@@ -104,7 +104,7 @@ func (bitfield *ConcurrentBitfield) SetBitfield(newInner Bitfield) {
 	bitfield.inner = newInner
 }
 
-func (bitfield *ConcurrentBitfield) AddPiece(piece int) {
+func (bitfield *ConcurrentBitfield) AddPiece(piece uint64) {
 	bitfield.mutex.Lock()
 	defer bitfield.mutex.Unlock()
 

--- a/download/peer/peer.go
+++ b/download/peer/peer.go
@@ -266,7 +266,7 @@ func (peer *Peer) listen(
 		case *message.NotInterested:
 			// TODO
 		case *message.Have:
-			peer.availablePieces.AddPiece(msg.Piece)
+			peer.availablePieces.AddPiece(uint64(msg.Piece))
 		case *message.Bitfield:
 			peer.availablePieces = bitfield.NewConcurrentBitfield(
 				msg.Bitfield,
@@ -295,10 +295,10 @@ func (peer *Peer) listen(
 
 					newState = pieces.NotDownloaded
 				} else {
-					globalOffset := int(msg.Piece) * torrent.PieceLength
+					globalOffset := uint64(msg.Piece) * torrent.PieceLength
 					downloadedPieces.WritePiece(
 						downloaded_files.DownloadedPiece{
-							Index:  msg.Piece,
+							Index:  uint64(msg.Piece),
 							Offset: globalOffset,
 							Data:   donePiece.Data,
 						},
@@ -376,8 +376,8 @@ Outer:
 
 			log.Printf("requesting piece #%d", pieceIdx)
 
-			pieceLength := min(torrent.PieceLength, torrent.TotalLength-pieceIdx*torrent.PieceLength)
-			peer.pendingPieces.Insert(pieceIdx, pieceLength)
+			pieceLength := min(torrent.PieceLength, torrent.TotalLength-uint64(pieceIdx)*torrent.PieceLength)
+			peer.pendingPieces.Insert(pieceIdx, int(pieceLength))
 
 			for _, block := range peer.pendingPieces.GetPendingBlocksForPiece(pieceIdx) {
 				message := message.Request{

--- a/download/pieces/pieces.go
+++ b/download/pieces/pieces.go
@@ -49,7 +49,7 @@ func (pieces *Pieces) GetBitfield() bitfield.Bitfield {
 	bitfield := bitfield.NewEmptyBitfield(len(pieces.pieces))
 	for i, state := range pieces.pieces {
 		if state == Downloaded {
-			bitfield.AddPiece(i)
+			bitfield.AddPiece(uint64(i))
 		}
 	}
 

--- a/download/torrent_info/torrent_info.go
+++ b/download/torrent_info/torrent_info.go
@@ -15,8 +15,8 @@ import (
 type TorrentInfo struct {
 	Trackers    []*url.URL
 	Pieces      [][sha1.Size]byte
-	PieceLength int
-	TotalLength int
+	PieceLength uint64
+	TotalLength uint64
 	Name        string
 	Files       []FileInfo
 
@@ -25,17 +25,17 @@ type TorrentInfo struct {
 
 type Metadata struct {
 	Pieces      [][sha1.Size]byte
-	PieceLength int
+	PieceLength uint64
 	Name        string
 	Files       []FileInfo
-	TotalLength int
+	TotalLength uint64
 
 	InfoHash [sha1.Size]byte
 }
 
 type FileInfo struct {
 	Path   []string
-	Length int
+	Length uint64
 }
 
 type bencodeTorrent struct {
@@ -46,15 +46,15 @@ type bencodeTorrent struct {
 
 type bencodeInfo struct {
 	Pieces      string             `bencode:"pieces"`
-	PieceLength int                `bencode:"piece length"`
+	PieceLength uint64             `bencode:"piece length"`
 	Name        string             `bencode:"name"`
 	Files       *[]bencodeFileInfo `bencode:"files"`
-	Length      *int               `bencode:"length"`
+	Length      *uint64            `bencode:"length"`
 }
 
 type bencodeFileInfo struct {
 	Path   []string `bencode:"path"`
-	Length int      `bencode:"length"`
+	Length uint64   `bencode:"length"`
 }
 
 func Decode(reader io.Reader) (*TorrentInfo, error) {
@@ -97,7 +97,7 @@ func Decode(reader io.Reader) (*TorrentInfo, error) {
 		pieces = append(pieces, [sha1.Size]byte(chunk))
 	}
 
-	totalLength := 0
+	totalLength := uint64(0)
 	files := make([]FileInfo, 0)
 	if bencodeTorrent.Info.Files != nil {
 		for _, file := range *bencodeTorrent.Info.Files {
@@ -146,7 +146,7 @@ func DecodeMetadata(reader io.Reader) (*Metadata, error) {
 		pieces = append(pieces, [sha1.Size]byte(chunk))
 	}
 
-	totalLength := 0
+	totalLength := uint64(0)
 	files := make([]FileInfo, 0)
 	if bencodeMetadata.Files != nil {
 		for _, file := range *bencodeMetadata.Files {

--- a/download/tracker/tracker.go
+++ b/download/tracker/tracker.go
@@ -51,12 +51,12 @@ type announceRequest struct {
 type Tracker struct {
 	url      *url.URL
 	infoHash [sha1.Size]byte
-	length   int
+	length   uint64
 	peerID   [20]byte
 	interval time.Duration
 }
 
-func NewTracker(url *url.URL, infoHash [sha1.Size]byte, length int, peerID [20]byte) *Tracker {
+func NewTracker(url *url.URL, infoHash [sha1.Size]byte, length uint64, peerID [20]byte) *Tracker {
 	return &Tracker{
 		url:      url,
 		infoHash: infoHash,


### PR DESCRIPTION
Resolves #46 